### PR TITLE
Switch submodule URL to HTTPS for unauthenticated cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/tjbot-config"]
 	path = vendor/tjbot-config
-	url = git@github.com:tjbot-ce/tjbot-config.git
+	url = https://github.com/tjbot-ce/tjbot-config.git


### PR DESCRIPTION
Fixed tjbot-config submodule URL so repo can be cloned unauthenticated 