### PR TITLE
fix: update version to 3.0.1 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tjbot-ce",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tjbot-ce",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tjbot-ce",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "TJBot: Community Edition - Node.js library for writing TJBot recipes",
   "dependencies": {
     "@iarna/toml": "^2.2.5",


### PR DESCRIPTION
Off to a great start with an `npm publish` misfire… so now we need to bump to 3.0.1!